### PR TITLE
Adding loose search matching and sorting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask~=3.0.2
 werkzeug~=3.0.6
 requests~=2.32.3
 flask-limiter~=3.8.0
+inflect~=7.0.0

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -6,5 +6,5 @@ test("Search functionality test", async ({ page }) => {
     await page.locator('input[name="lookup"]').fill("galaxy");
     await page.locator('input[type="submit"]').click();
 
-    await expect(page).toHaveURL(/\/uat\/\?view=search&lookup=galaxy&sort=alpha/);
+    await expect(page).toHaveURL(/\/uat\/\?view=search&lookup=galaxy&sort=relevance/);
 });

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -6,5 +6,5 @@ test("Search functionality test", async ({ page }) => {
     await page.locator('input[name="lookup"]').fill("galaxy");
     await page.locator('input[type="submit"]').click();
 
-    await expect(page).toHaveURL(/\/uat\/\?view=search&lookup=galaxy/);
+    await expect(page).toHaveURL(/\/uat\/\?view=search&lookup=galaxy&sort=alpha/);
 });

--- a/uat-web-app/data_generator.py
+++ b/uat-web-app/data_generator.py
@@ -137,6 +137,8 @@ def search_terms(lookup_term, alpha_terms, sort_direction="alpha"):
         results.sort(key=lambda x: (x["_rank"], x["name"].lower()))
     else:
         results.sort(key=lambda x: (x["name"].lower()))
+    for result in results: # Remove the _rank key from the result
+        result.pop("_rank", None)
     return results
 
 
@@ -156,87 +158,85 @@ def search_term(lookup_term, lookup_variants, normalized_lookup, term):
         dict or None: A dictionary with highlighted and ranked match information
         if a match is found, otherwise None.
     """
-    normalized_name = normalize_term(term["name"])
-    normalized_uri = normalize_term(str(term["uri"][30:]))
-
-    matched = False
     term_dict = {}
     best_rank = 100
     # URI matching
     uri = str(term["uri"][30:])
+    normalized_uri = normalize_term(uri)
     if lookup_term == uri:
-        rank, matched = 1, True
+        rank = 1
     elif uri.startswith(lookup_term):
-        rank, matched = 2, True
+        rank = 2
     elif lookup_term in uri:
-        rank, matched = 3, True
+        rank = 3
     elif normalized_lookup == normalized_uri:
-        rank, matched = 4, True
+        rank = 4
     elif normalized_lookup in normalized_uri:
-        rank, matched = 5, True
+        rank = 5
     else:
         rank = 100
-    if matched and rank < best_rank:
+    if rank < best_rank:
         best_rank = rank
         term_dict["uri"] = uri.replace(lookup_term, "<mark>" + lookup_term + "</mark>")
     # Name matching
-    matched_name = False
+    rank = 100
     for variant in lookup_variants:
         if variant == term["name"]:
-            rank, matched_name = 1, True
+            rank = 1
             term_dict["name"] = highlight_text(term["name"], variant)
             break
         elif term["name"].startswith(variant):
-            rank, matched_name = 2, True
+            rank = 2
             term_dict["name"] = highlight_text(term["name"], variant)
             break
         elif variant in term["name"]:
-            rank, matched_name = 3, True
+            rank = 3
             term_dict["name"] = highlight_text(term["name"], variant)
             break
-    if not matched_name:
+    if rank >= 100:  # No match found with variants
+        normalized_name = normalize_term(term["name"])
         if normalized_lookup == normalized_name:
-            rank, matched_name = 4, True
+            rank = 4
             term_dict["name"] = term["name"]
         elif normalized_lookup in normalized_name:
-            rank, matched_name = 5, True
+            rank = 5
             term_dict["name"] = term["name"]
-    if matched_name and rank < best_rank:
-        best_rank, matched = rank, True
+    if rank < best_rank:
+        best_rank = rank
     # altNames matching
     highlighted_alts = []
     if term.get("altNames"):
         for alt_name in term["altNames"]:
-            alt_matched = False
+            rank = 100
             for variant in lookup_variants:
                 if variant == alt_name:
-                    rank, alt_matched = 1, True
+                    rank = 1
                     highlighted_alts.append(highlight_text(alt_name, variant))
                     break
                 elif alt_name.startswith(variant):
-                    rank, alt_matched = 2, True
+                    rank = 2
                     highlighted_alts.append(highlight_text(alt_name, variant))
                     break
                 elif variant in alt_name:
-                    rank, alt_matched = 3, True
+                    rank = 3
                     highlighted_alts.append(highlight_text(alt_name, variant))
                     break
-            if not alt_matched:
+            if rank >= 100:  # No match found with variants
                 normalized_alt = normalize_term(alt_name)
                 if normalized_lookup == normalized_alt:
-                    rank, alt_matched = 4, True
+                    rank = 4
                     highlighted_alts.append(alt_name)
                 elif normalized_lookup in normalized_alt:
-                    rank, alt_matched = 5, True
+                    rank = 5
                     highlighted_alts.append(alt_name)
-            if alt_matched and rank < best_rank:
-                best_rank, matched = rank, True
+            if rank < best_rank:
+                best_rank = rank
 
         if highlighted_alts:
             # Sort the highlighted alternatives alphabetically only
             highlighted_alts.sort(key=lambda x: x.lower())
             term_dict["altNames"] = highlighted_alts
-    if matched:
+    if best_rank < 100:
         term_dict["_rank"] = best_rank
         if term_dict.get("uri") is None:
             term_dict["uri"] = uri
@@ -319,16 +319,15 @@ def get_element_and_status(uat_id, alpha_terms, view_type):
 
 def retrieve_sorting_tool_data(tag, file_list):
     """
-    Retrieves data for the sorting tool page.
+    Prepares and returns context data for rendering the sorting tool page.
 
     Args:
-        tag (str): The tag for the UAT version.
-        file_list (list): The list of files for sorting.
+        tag (str): The version tag for the UAT data.
+        file_list (list): List of files to be displayed or sorted.
 
     Returns:
-        dict: The data for the sorting tool page.
-        tag: The tag for the UAT version.
-        file_list: Sorting data
+        dict: A dictionary containing sorting tool page data,
+        including file list, UAT metadata, and configuration.
     """
     return {
         "filelist": file_list,

--- a/uat-web-app/data_generator.py
+++ b/uat-web-app/data_generator.py
@@ -61,7 +61,7 @@ def retrieve_alpha_page_data(uat_id, alpha_terms, html_tree):
     """
     view_type = request.args.get("view", "alpha")
     lookup_term = request.args.get("lookup") if view_type == "search" else None
-    sort_direction = request.args.get("sort", "alpha") if view_type == "search" else None
+    sort_direction = request.args.get("sort", "relevance") if view_type == "search" else None
     results = search_terms(lookup_term, alpha_terms, sort_direction) \
         if view_type == "search" else []
     all_paths = get_paths(request.args.get("path")) if view_type == "hierarchy" else []
@@ -92,14 +92,14 @@ def normalize_term(term):
     - Converts plurals to singular using inflect
     """
     term = term.lower()
-    term = re.sub(r"[\s\-_'\"/.,!?;:()“”’‘]", "", term)
+    term = re.sub(r"[\s\-_'\"\/.,!?;:()“”’‘]", "", term)
     singular = inflector.singular_noun(term)
     if singular:
         term = singular
     return term
 
 
-def search_terms(lookup_term, alpha_terms, sort_direction="alpha"):
+def search_terms(lookup_term, alpha_terms, sort_direction="relevance"):
     """
     Searches for terms in the provided list that match the lookup term,
     using various normalization and matching strategies.
@@ -109,7 +109,7 @@ def search_terms(lookup_term, alpha_terms, sort_direction="alpha"):
         lookup_term (str): The search term entered by the user.
         alpha_terms (list): List of term dictionaries to search within.
         sort_direction (str, optional): Sorting method for results;
-        "relevance" sorts by match rank, "alpha" sorts alphabetically. Defaults to "alpha".
+        "relevance" sorts by match rank, "alpha" sorts alphabetically.
 
     Returns:
         list: A list of dictionaries representing matched terms,

--- a/uat-web-app/data_generator.py
+++ b/uat-web-app/data_generator.py
@@ -135,7 +135,7 @@ def search_terms(lookup_term, alpha_terms, sort_direction="alpha"):
 
     if sort_direction == "relevance":
         results.sort(key=lambda x: (x["_rank"], x["name"].lower()))
-    for result in results: # Remove the _rank key from the result
+    for result in results:  # Remove the _rank key from the result
         result.pop("_rank", None)
     return results
 

--- a/uat-web-app/data_generator.py
+++ b/uat-web-app/data_generator.py
@@ -135,8 +135,6 @@ def search_terms(lookup_term, alpha_terms, sort_direction="alpha"):
 
     if sort_direction == "relevance":
         results.sort(key=lambda x: (x["_rank"], x["name"].lower()))
-    else:
-        results.sort(key=lambda x: (x["name"].lower()))
     for result in results: # Remove the _rank key from the result
         result.pop("_rank", None)
     return results

--- a/uat-web-app/routes.py
+++ b/uat-web-app/routes.py
@@ -90,7 +90,7 @@ def sorting_tool():
     Returns:
         str: Rendered HTML template for the sorting tool page with data.
     """
-    data = retrieve_sorting_tool_data(app, uat_manager.current_tag, uat_manager.file_list)
+    data = retrieve_sorting_tool_data(uat_manager.current_tag, uat_manager.file_list)
     return render_template("sorting.html", title="UAT Web App - Sorting Tool", **data)
 
 

--- a/uat-web-app/templates/alpha.html
+++ b/uat-web-app/templates/alpha.html
@@ -247,6 +247,9 @@
                 {% if lookup %}
 
                     <b>Search Query: {{ lookup }}</b>
+                    {% if results is defined %}
+                        <span>({{ results|length }} result{{ 's' if results|length != 1 else '' }})</span>
+                    {% endif %}
                     <br/><br/>
 
                     {% for y in results %}

--- a/uat-web-app/templates/alpha.html
+++ b/uat-web-app/templates/alpha.html
@@ -248,7 +248,7 @@
 
                     <b>Search Query: {{ lookup }}</b>
                     {% if results is defined %}
-                        <span>({{ results|length }} result{{ 's' if results|length != 1 else '' }})</span>
+                        <span aria-live="polite">({{ results|length }} result{{ 's' if results|length != 1 else '' }})</span>
                     {% endif %}
                     <br/><br/>
 

--- a/uat-web-app/templates/alpha.html
+++ b/uat-web-app/templates/alpha.html
@@ -220,7 +220,7 @@
                         <br/><br/>
                         <label for="searchButton"></label><input type="submit" id="searchButton" value="Search"
                                                                  {% if lookup is none %}disabled {% endif %}/>
-                        <input type="reset" value="Reset" onclick="setTimeout(checkInput, 0)"/>
+                        <input type="reset" value="Reset" onclick="checkInput()"/>
                         <input type="button" value="Clear" onclick="clearSearchForm()" />
                     </form>
                     <br/><br/>

--- a/uat-web-app/templates/alpha.html
+++ b/uat-web-app/templates/alpha.html
@@ -58,6 +58,12 @@
         const button = document.getElementById("searchButton");
         button.disabled = input.trim() === "";
     }
+
+    function clearSearchForm() {
+        document.getElementById("uatlookup").value = "";
+        document.getElementById("sortOrder").value = "alpha";
+        checkInput();
+    }
 </script>
 <span id="topm"></span>
 <div class="container-fluid">
@@ -201,12 +207,21 @@
 
                     <form action="" name="searchform">
                         <input type="hidden" id="uatview" name="view" value="search"/>
-                        <input type="text" id="uatlookup" name="lookup" oninput="checkInput()"/>
+                        <input type="text" id="uatlookup" name="lookup" oninput="checkInput()"
+                        {% if lookup %} value="{{ lookup }}" {% endif %}/>
+                        <br/><br/>
+                        <label for="sortOrder">Sort by:</label>
+                        <select id="sortOrder" name="sort">
+                            <option value="alpha" {% if sort is none or sort == 'alpha' %}selected{% endif %}>Alphabetical</option>
+                            <option value="relevance" {% if sort == 'relevance' %}selected{% endif %}>Best Match</option>
+                        </select>
                         <!--                         <br>
                                                 <input type="checkbox" id="searchdef" name="searchdef"> Also search defintions? -->
                         <br/><br/>
                         <label for="searchButton"></label><input type="submit" id="searchButton" value="Search"
-                                                                 disabled/>
+                                                                 {% if lookup is none %}disabled {% endif %}/>
+                        <input type="reset" value="Reset" onclick="setTimeout(checkInput, 0)"/>
+                        <input type="button" value="Clear" onclick="clearSearchForm()" />
                     </form>
                     <br/><br/>
 
@@ -240,7 +255,9 @@
                                     href="{{ y.uri|replace('<mark>', '')|replace('</mark>', '') }}">{{ y.name|safe }}</a></strong>
                             (https://astrothesaurus.org/uat/{{ y.uri|safe }})
                             {% if y.altNames %}
-                                <br/><i>Alternate term:</i> {{ y.altNames|safe }}
+                                {% for value in y.altNames %}
+                                    <br/><i>Alternate term:</i> {{ value|safe }}
+                                {% endfor %}
                             {% endif %}
                             {% if y.definition %}
                                 <br/><i>Definition:</i> {{ y.definition|safe }}

--- a/uat-web-app/templates/alpha.html
+++ b/uat-web-app/templates/alpha.html
@@ -61,8 +61,8 @@
 
     function clearSearchForm() {
         document.getElementById("uatlookup").value = "";
-        document.getElementById("sortOrder").value = "alpha";
-        checkInput();
+        document.getElementById("sortOrder").value = "relevance";
+        document.getElementById("searchButton").disabled = true;
     }
 </script>
 <span id="topm"></span>
@@ -207,20 +207,17 @@
 
                     <form action="" name="searchform">
                         <input type="hidden" id="uatview" name="view" value="search"/>
-                        <input type="text" id="uatlookup" name="lookup" oninput="checkInput()"
-                        {% if lookup %} value="{{ lookup }}" {% endif %}/>
+                        <input type="text" id="uatlookup" name="lookup" oninput="checkInput()"/>
                         <br/><br/>
                         <label for="sortOrder">Sort by:</label>
                         <select id="sortOrder" name="sort">
-                            <option value="alpha" {% if sort is none or sort == 'alpha' %}selected{% endif %}>Alphabetical</option>
-                            <option value="relevance" {% if sort == 'relevance' %}selected{% endif %}>Best Match</option>
+                            <option value="alpha">Alphabetical</option>
+                            <option value="relevance">Best Match</option>
                         </select>
                         <!--                         <br>
                                                 <input type="checkbox" id="searchdef" name="searchdef"> Also search defintions? -->
                         <br/><br/>
-                        <label for="searchButton"></label><input type="submit" id="searchButton" value="Search"
-                                                                 {% if lookup is none %}disabled {% endif %}/>
-                        <input type="reset" value="Reset" onclick="checkInput()"/>
+                        <label for="searchButton"></label><input type="submit" id="searchButton" value="Search"/>
                         <input type="button" value="Clear" onclick="clearSearchForm()" />
                     </form>
                     <br/><br/>
@@ -417,6 +414,25 @@
 
 
 <script>
+    function setFormFromUrl() {
+        const params = new URLSearchParams(window.location.search);
+        const sort = params.get("sort");
+        if (sort !== null) {
+            document.getElementById("sortOrder").value = sort;
+        } else {
+            document.getElementById("sortOrder").value = "relevance";
+        }
+        const lookup = params.get("lookup");
+        if (lookup !== null) {
+            document.getElementById("uatlookup").value = lookup;
+        } else {
+            document.getElementById("uatlookup").value = "";
+        }
+        checkInput();
+    }
+
+    document.addEventListener("DOMContentLoaded", setFormFromUrl);
+    window.addEventListener("pageshow", setFormFromUrl);
 
     const STICKY_TAB_HEIGHT = 48; // Height of the sticky tab in pixels
     $(document).ready(function () {

--- a/uat-web-app/tests/test_data_generator.py
+++ b/uat-web-app/tests/test_data_generator.py
@@ -176,8 +176,7 @@ class TestDataGenerator(unittest.TestCase):
                           "Magnetic"]}
         ]
         lookup_term = "Magnetics"
-        expected_results = [{'_rank': 1,
-                             'altNames': ['<mark>Magnetics</mark>',
+        expected_results = [{'altNames': ['<mark>Magnetics</mark>',
                                           '<mark>Magnetics</mark> fields',
                                           'Magnetic',
                                           'Milky Way Galaxy <mark>magnetics</mark> fields'],
@@ -198,8 +197,7 @@ class TestDataGenerator(unittest.TestCase):
              "altNames": ["Magnetic fields"]}
         ]
         lookup_term = "321"
-        expected_results = [{'_rank': 1,
-                             'name': 'Cosmic magnetic fields theory',
+        expected_results = [{'name': 'Cosmic magnetic fields theory',
                              'uri': '<mark>321</mark>'}]
 
         results = data_generator.search_terms(lookup_term, alpha_terms)
@@ -216,12 +214,11 @@ class TestDataGenerator(unittest.TestCase):
              "altNames": ["Magnetic fields"]}
         ]
         lookup_term = "Astro processes"
-        expected_results = [{'_rank': 1,
-                             'altNames': ['Astro-processes'],
+        expected_results = [{'altNames': ['Astro-processes'],
                              'name': '<mark>Astro processes</mark>',
                              'uri': '104'}]
 
-        results = data_generator.search_terms(lookup_term, alpha_terms)
+        results = data_generator.search_terms(lookup_term, alpha_terms, "relevance")
 
         self.assertEqual(expected_results, results)
 

--- a/uat-web-app/tests/test_data_generator.py
+++ b/uat-web-app/tests/test_data_generator.py
@@ -172,10 +172,17 @@ class TestDataGenerator(unittest.TestCase):
             {"uri": "http://astrothesaurus.org/uat/102", "name": "Astrophysical magnetism",
              "altNames": []},
             {"uri": "http://astrothesaurus.org/uat/321", "name": "Cosmic magnetic fields theory",
-             "altNames": ["Magnetic fields"]}
+             "altNames": ["Magnetics", "Magnetics fields", "Milky Way Galaxy magnetics fields",
+                          "Magentic"]}
         ]
-        lookup_term = "Magnetic"
-        expected_results = [{'name': 'Cosmic <mark>magnetic</mark> fields theory', 'uri': '321'}]
+        lookup_term = "Magnetics"
+        expected_results = [{'_rank': 1,
+                             '_type': 2,
+                             'altNames': ['<mark>Magnetics</mark>',
+                                          '<mark>Magnetics</mark> fields',
+                                          'Milky Way Galaxy <mark>magnetics</mark> fields'],
+                             'name': 'Cosmic magnetic fields theory',
+                             'uri': '321'}]
 
         results = data_generator.search_terms(lookup_term, alpha_terms)
 
@@ -191,7 +198,10 @@ class TestDataGenerator(unittest.TestCase):
              "altNames": ["Magnetic fields"]}
         ]
         lookup_term = "321"
-        expected_results = [{'name': 'Cosmic magnetic fields theory', 'uri': '<mark>321</mark>'}]
+        expected_results = [{'_rank': 1,
+                             '_type': 0,
+                             'name': 'Cosmic magnetic fields theory',
+                             'uri': '<mark>321</mark>'}]
 
         results = data_generator.search_terms(lookup_term, alpha_terms)
 
@@ -199,16 +209,19 @@ class TestDataGenerator(unittest.TestCase):
 
     def test_search_terms_alt_name_no_status(self):
         alpha_terms = [
-            {"uri": "http://astrothesaurus.org/uat/104", "name": "Astrophysical processes",
-             "altNames": ["Astro processes"]},
+            {"uri": "http://astrothesaurus.org/uat/104", "name": "Astro processes",
+             "altNames": ["Astro-processes"]},
             {"uri": "http://astrothesaurus.org/uat/102", "name": "Astrophysical magnetism",
              "altNames": []},
             {"uri": "http://astrothesaurus.org/uat/321", "name": "Cosmic magnetic fields theory",
              "altNames": ["Magnetic fields"]}
         ]
         lookup_term = "Astro processes"
-        expected_results = [{'altNames': '<mark>Astro processes</mark>',
-                             'name': 'Astrophysical processes', 'uri': '104'}]
+        expected_results = [{'_rank': 1,
+                             '_type': 1,
+                             'altNames': ['Astro-processes'],
+                             'name': '<mark>Astro processes</mark>',
+                             'uri': '104'}]
 
         results = data_generator.search_terms(lookup_term, alpha_terms)
 

--- a/uat-web-app/tests/test_data_generator.py
+++ b/uat-web-app/tests/test_data_generator.py
@@ -218,7 +218,7 @@ class TestDataGenerator(unittest.TestCase):
                              'name': '<mark>Astro processes</mark>',
                              'uri': '104'}]
 
-        results = data_generator.search_terms(lookup_term, alpha_terms, "relevance")
+        results = data_generator.search_terms(lookup_term, alpha_terms, "alpha")
 
         self.assertEqual(expected_results, results)
 

--- a/uat-web-app/tests/test_data_generator.py
+++ b/uat-web-app/tests/test_data_generator.py
@@ -177,7 +177,6 @@ class TestDataGenerator(unittest.TestCase):
         ]
         lookup_term = "Magnetics"
         expected_results = [{'_rank': 1,
-                             '_type': 2,
                              'altNames': ['<mark>Magnetics</mark>',
                                           '<mark>Magnetics</mark> fields',
                                           'Milky Way Galaxy <mark>magnetics</mark> fields'],
@@ -199,7 +198,6 @@ class TestDataGenerator(unittest.TestCase):
         ]
         lookup_term = "321"
         expected_results = [{'_rank': 1,
-                             '_type': 0,
                              'name': 'Cosmic magnetic fields theory',
                              'uri': '<mark>321</mark>'}]
 
@@ -218,7 +216,6 @@ class TestDataGenerator(unittest.TestCase):
         ]
         lookup_term = "Astro processes"
         expected_results = [{'_rank': 1,
-                             '_type': 1,
                              'altNames': ['Astro-processes'],
                              'name': '<mark>Astro processes</mark>',
                              'uri': '104'}]

--- a/uat-web-app/tests/test_data_generator.py
+++ b/uat-web-app/tests/test_data_generator.py
@@ -27,7 +27,7 @@ class TestDataGenerator(unittest.TestCase):
                     "children": {
                         "name": "Cosmology", }}]}
 
-        result = data_generator.retrieve_sorting_tool_data(self.app, "v.5.1.0", filelist)
+        result = data_generator.retrieve_sorting_tool_data("v.5.1.0", filelist)
 
         self.assertEqual(2, len(result["filelist"]))
         self.assertEqual(filelist, result["filelist"])
@@ -173,12 +173,13 @@ class TestDataGenerator(unittest.TestCase):
              "altNames": []},
             {"uri": "http://astrothesaurus.org/uat/321", "name": "Cosmic magnetic fields theory",
              "altNames": ["Magnetics", "Magnetics fields", "Milky Way Galaxy magnetics fields",
-                          "Magentic"]}
+                          "Magnetic"]}
         ]
         lookup_term = "Magnetics"
         expected_results = [{'_rank': 1,
                              'altNames': ['<mark>Magnetics</mark>',
                                           '<mark>Magnetics</mark> fields',
+                                          'Magnetic',
                                           'Milky Way Galaxy <mark>magnetics</mark> fields'],
                              'name': 'Cosmic magnetic fields theory',
                              'uri': '321'}]


### PR DESCRIPTION
* Adding looser search instead of strict for the UAT
* Adding sort drop down to search by either alphabetical or best matching
* Adding clear button to search
* Adding result count at top of page
* Fixing bug when multiple alternate terms match, only the first matching one is shown. Alternate terms will always be sorted alphabetically.

<img width="373" height="340" alt="Screenshot 2025-07-10 224432" src="https://github.com/user-attachments/assets/429809f0-6094-43a8-b5eb-03c8e13b370c" />
<img width="1159" height="984" alt="image" src="https://github.com/user-attachments/assets/904057c8-c209-4c6f-a416-1fc3593e52a1" />
